### PR TITLE
[CHORE] eslint no-use-before-define 변수 끄기

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,7 @@ module.exports = {
 		'react/jsx-filename-extension': ['warn', { extensions: ['.tsx'] }],
 		'react/react-in-jsx-scope': 'off',
 		'import/no-extraneous-dependencies': 0,
+		'no-use-before-define': ['error', { functions: true, classes: true, variables: false }],
 		'import/extensions': [
 			'error',
 			'ignorePackages',


### PR DESCRIPTION
## 작업 내용 :technologist:

- 1) eslint no-use-before-define 변수 끄기

## 알게된 점 :rocket:

> 기록하며 개발하기!

- airbnb 룰 사용하면서 styled-component 사용 위해 no-use-before-define 설정에서 변수 껐습니다

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요



## 스크린샷 (선택)
