### PR TITLE
[FEAT] 영화관, 상영관, 영화시간 리스트 API 연결

### DIFF
--- a/src/apis/getTheaters.ts
+++ b/src/apis/getTheaters.ts
@@ -1,0 +1,32 @@
+import { isAxiosError } from 'axios';
+import serverAxios from './serverAxios';
+
+/** time 페이지 영화관, 상영관 리스트 */
+const getTheaters = async (movieId: number, cinemaId: number) => {
+	try {
+		const res = await serverAxios.get('/api/v1/theaters', {
+			params: {
+				movie: movieId,
+				cinema: cinemaId,
+			},
+		});
+		return res.data;
+	} catch (error) {
+		if (isAxiosError(error)) {
+			const statusCode = error.response?.status;
+			let errorMessage = 'error occurred';
+			if (!statusCode) {
+				errorMessage = 'Network error';
+			} else if (statusCode >= 500) {
+				errorMessage = 'Server error';
+			} else if (statusCode === 400 || statusCode === 404) {
+				errorMessage = '잘못된 요청';
+			}
+			throw new Error(errorMessage);
+		} else {
+			throw new Error('unknown error');
+		}
+	}
+};
+
+export default getTheaters;

--- a/src/components/time/dateSelect/ThisWeek.tsx
+++ b/src/components/time/dateSelect/ThisWeek.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
+import { useState } from 'react';
 import Typo from '../../../styles/typo/typo';
 import { getColorByDay, formatDate, formatToday } from '../../../utils/time/dateUtils';
 import timeIcons from '../../../assets/time/icon/index';
 
 function ThisWeek() {
+	const [selectedDay, setSelectedDay] = useState<number | null>(null);
 	const today = new Date();
 
 	/** 이번주 일주일 생성 */
@@ -21,6 +23,10 @@ function ThisWeek() {
 		};
 	});
 
+	const handleDayClick = (day: number) => {
+		setSelectedDay(day);
+	};
+
 	return (
 		<>
 			<TodayWrapper>
@@ -31,7 +37,11 @@ function ThisWeek() {
 
 			<WeekDateContainer>
 				{weekDates.map((weekDate) => (
-					<WeekDateWrapper key={weekDate.uniqueKey}>
+					<WeekDateWrapper
+						key={weekDate.uniqueKey}
+						onClick={() => handleDayClick(weekDate.day)}
+						$isSelected={selectedDay === weekDate.day}
+					>
 						<Typo.Head.Head1SB17>{weekDate.day}</Typo.Head.Head1SB17>
 						{weekDate.label === '내일' ? (
 							<Red>{weekDate.label}</Red>
@@ -70,16 +80,32 @@ interface DayOfWeekProps {
 
 /* util에서 요일 색상 불러오기 */
 const DayOfWeek = styled(Typo.Body.Body5M13)<DayOfWeekProps>`
-	margin-top: 1rem;
+	margin-top: 0.8rem;
 
 	color: ${({ $dayOfWeek }) => getColorByDay($dayOfWeek)};
 `;
 
-const WeekDateWrapper = styled.div`
+interface WeekDateWrapperProps {
+	$isSelected: boolean;
+}
+
+const WeekDateWrapper = styled.div<WeekDateWrapperProps>`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	padding: 1rem;
+	margin-bottom: 1rem;
+
+	cursor: pointer;
+	border-radius: 8px;
+
+	:first-child {
+		padding: 1rem;
+
+		color: ${({ $isSelected, theme }) => ($isSelected ? theme.GreyScale.White : theme.GreyScale.Black)};
+
+		background-color: ${({ $isSelected, theme }) => ($isSelected ? theme.Color.Point : 'transparent')};
+		border-radius: 11px;
+	}
 `;
 
 const WeekDateContainer = styled.div`
@@ -101,6 +127,7 @@ const Red = styled(Typo.Body.Body5M13)`
 
 	color: ${(props) => props.theme.Color.Point};
 `;
+
 const SortBar = styled.div`
 	display: flex;
 	gap: 1rem;
@@ -124,6 +151,7 @@ const SortBar = styled.div`
 const Filter = styled(Typo.Body.Body3M14)`
 	color: ${({ color, theme }) => color || theme.GreyScale.BG};
 `;
+
 const FilterWrapper = styled.div`
 	position: relative;
 	left: 16rem;

--- a/src/components/time/timeList/EachTheatersTimeList.tsx
+++ b/src/components/time/timeList/EachTheatersTimeList.tsx
@@ -11,7 +11,12 @@ function EachTheatersTimeList({ times }: EachTheatersTimeListProps) {
 	return (
 		<RunningTimeSeatsContainer>
 			{times.map((time) => (
-				<RunningTimeSeatsWrapper key={time.startAt} startAt={time.startAt} endAt={time.endAt} />
+				<RunningTimeSeatsWrapper
+					key={time.startAt}
+					startAt={time.startAt}
+					endAt={time.endAt}
+					remainingSeats={time.remainingSeats}
+				/>
 			))}
 		</RunningTimeSeatsContainer>
 	);

--- a/src/components/time/timeList/EachTheatersTimeList.tsx
+++ b/src/components/time/timeList/EachTheatersTimeList.tsx
@@ -1,15 +1,18 @@
 import styled from 'styled-components';
 import RunningTimeSeatsWrapper from './RunningTimeSeatsWrapper';
+import { Time } from './EachTheatersTimeSection';
+
+interface EachTheatersTimeListProps {
+	times: Time[];
+}
 
 /** 각 상영관 시간&잔여석 정보 */
-function EachTheatersTimeList() {
+function EachTheatersTimeList({ times }: EachTheatersTimeListProps) {
 	return (
 		<RunningTimeSeatsContainer>
-			{/* TODO: 각 영화관 상영시간 개수만큼 보여주기 */}
-			<RunningTimeSeatsWrapper />
-			<RunningTimeSeatsWrapper />
-			<RunningTimeSeatsWrapper />
-			<RunningTimeSeatsWrapper />
+			{times.map((time) => (
+				<RunningTimeSeatsWrapper key={time.startAt} startAt={time.startAt} endAt={time.endAt} />
+			))}
 		</RunningTimeSeatsContainer>
 	);
 }

--- a/src/components/time/timeList/EachTheatersTimeSection.tsx
+++ b/src/components/time/timeList/EachTheatersTimeSection.tsx
@@ -1,21 +1,51 @@
 import styled from 'styled-components';
+import { useEffect, useState } from 'react';
 import Typo from '../../../styles/typo/typo';
 import EachTheatersTimeList from './EachTheatersTimeList';
 import timeIcons from '../../../assets/time/icon';
+import getTheaters from '../../../apis/getTheaters';
+
+// 데이터 타입 선언
+interface Theater {
+	theaterId: number;
+	theaterName: string;
+	maxSeats: number;
+	theaterType: string;
+}
 
 /** 각 상영관 정보 섹션 */
 function EachTheatersTimeSection() {
+	const [theaters, setTheaters] = useState<Theater[]>([]);
+
+	const movieId = 3;
+	const cinemaId = 28;
+
+	// 영화관, 상영관 정보 가져오는 api 통신
+	const getTheaterApi = async () => {
+		const res = await getTheaters(movieId, cinemaId);
+		const theaterInfo = res.movies[0].cinemas[0].theaters;
+		setTheaters(theaterInfo);
+	};
+
+	useEffect(() => {
+		getTheaterApi();
+	}, []);
 	return (
 		<SectionContainer>
-			<TheaterInfoContainer>
-				<Typo.Title.Title8B15>2D</Typo.Title.Title8B15>
-				<TheaterInfoWrapper>
-					<TheaterInfo>1관 6층</TheaterInfo>
-					<img src={timeIcons.icTimeLine} alt="|" width={12} height={12} />
-					<TheaterInfo>총 158석</TheaterInfo>
-				</TheaterInfoWrapper>
-			</TheaterInfoContainer>
-			<EachTheatersTimeList />
+			{theaters.map((theater) => (
+				<div key={theater.theaterId}>
+					<TheaterInfoContainer>
+						<Typo.Title.Title8B15>{theater.theaterType}</Typo.Title.Title8B15>
+						<TheaterInfoWrapper>
+							<TheaterInfo>{theater.theaterName}</TheaterInfo>
+							<img src={timeIcons.icTimeLine} alt="|" width={12} height={12} />
+							<TheaterInfo>총 {theater.maxSeats}석</TheaterInfo>
+						</TheaterInfoWrapper>
+					</TheaterInfoContainer>
+
+					<EachTheatersTimeList />
+				</div>
+			))}
 		</SectionContainer>
 	);
 }

--- a/src/components/time/timeList/EachTheatersTimeSection.tsx
+++ b/src/components/time/timeList/EachTheatersTimeSection.tsx
@@ -6,11 +6,18 @@ import timeIcons from '../../../assets/time/icon';
 import getTheaters from '../../../apis/getTheaters';
 
 // 데이터 타입 선언
+export interface Time {
+	startAt: string;
+	endAt: string;
+	remainingSeats: number;
+}
+
 interface Theater {
 	theaterId: number;
 	theaterName: string;
 	maxSeats: number;
 	theaterType: string;
+	times: Time[];
 }
 
 /** 각 상영관 정보 섹션 */
@@ -43,7 +50,7 @@ function EachTheatersTimeSection() {
 						</TheaterInfoWrapper>
 					</TheaterInfoContainer>
 
-					<EachTheatersTimeList />
+					<EachTheatersTimeList times={theater.times} />
 				</div>
 			))}
 		</SectionContainer>

--- a/src/components/time/timeList/RunningTime.tsx
+++ b/src/components/time/timeList/RunningTime.tsx
@@ -1,11 +1,16 @@
 import styled from 'styled-components';
 import Typo from '../../../styles/typo/typo';
 
-function RunningTime() {
+interface RunningTimeProps {
+	startAt: string;
+	endAt: string;
+}
+
+function RunningTime({ startAt, endAt }: RunningTimeProps) {
 	return (
 		<RunningTimeWrapper>
-			<Typo.Title.Title6B18>07:40</Typo.Title.Title6B18>
-			<EndTime>~09:39</EndTime>
+			<Typo.Title.Title6B18>{startAt}</Typo.Title.Title6B18>
+			<EndTime>~{endAt}</EndTime>
 		</RunningTimeWrapper>
 	);
 }

--- a/src/components/time/timeList/RunningTimeSeatsWrapper.tsx
+++ b/src/components/time/timeList/RunningTimeSeatsWrapper.tsx
@@ -2,10 +2,15 @@ import styled from 'styled-components';
 import RunningTime from './RunningTime';
 import Seats from './Seats';
 
-function RunningTimeSeatsWrapper() {
+interface RunningTimeSeatsWrapperProps {
+	startAt: string;
+	endAt: string;
+}
+
+function RunningTimeSeatsWrapper({ startAt, endAt }: RunningTimeSeatsWrapperProps) {
 	return (
 		<TimeSeatsWrapper>
-			<RunningTime />
+			<RunningTime startAt={startAt} endAt={endAt} />
 			<Seats />
 		</TimeSeatsWrapper>
 	);

--- a/src/components/time/timeList/RunningTimeSeatsWrapper.tsx
+++ b/src/components/time/timeList/RunningTimeSeatsWrapper.tsx
@@ -5,13 +5,14 @@ import Seats from './Seats';
 interface RunningTimeSeatsWrapperProps {
 	startAt: string;
 	endAt: string;
+	remainingSeats: number;
 }
 
-function RunningTimeSeatsWrapper({ startAt, endAt }: RunningTimeSeatsWrapperProps) {
+function RunningTimeSeatsWrapper({ startAt, endAt, remainingSeats }: RunningTimeSeatsWrapperProps) {
 	return (
 		<TimeSeatsWrapper>
 			<RunningTime startAt={startAt} endAt={endAt} />
-			<Seats />
+			<Seats remainingSeats={remainingSeats} />
 		</TimeSeatsWrapper>
 	);
 }

--- a/src/components/time/timeList/Seats.tsx
+++ b/src/components/time/timeList/Seats.tsx
@@ -1,11 +1,15 @@
 import styled from 'styled-components';
 import Typo from '../../../styles/typo/typo';
 
-function Seats() {
+interface SeatsProps {
+	remainingSeats: number;
+}
+
+function Seats({ remainingSeats }: SeatsProps) {
 	return (
 		<SeatsWrapper>
 			<FirstLabel>잔여</FirstLabel>
-			<RemainSeatsNum>154</RemainSeatsNum>
+			<RemainSeatsNum>{remainingSeats}</RemainSeatsNum>
 			<Typo.Num.Number4Timesmall>석</Typo.Num.Number4Timesmall>
 		</SeatsWrapper>
 	);

--- a/src/components/time/timeList/TimeToggleSection.tsx
+++ b/src/components/time/timeList/TimeToggleSection.tsx
@@ -5,7 +5,7 @@ import TimeToggleButton from './TimeToggleButton';
 import TimeList from './TimeList';
 
 function TimeToggleSection() {
-	const [isOpenTimeList, setOpenTimeList] = useState<boolean>(true);
+	const [isOpenTimeList, setOpenTimeList] = useState<boolean>(false);
 	return (
 		<TimeToggleSectionContainer>
 			<TimeToggleSectionWrapper>


### PR DESCRIPTION
## 작업 내용 :technologist:

- 영화관, 상영관, 영화시간 리스트의 API를 연결했습니다.
- 날짜를 선택하면 빨간색 div 박스로 선택되도록 추가했습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 타입 정의를 EachTheatersTimeSection 모듈에서 내보내고, 이를 다른 모듈에서 가져오는 식으로 구현할 수 있다.!! (아래는 예시 코드...)
1. EachTheatersTimeSection에서 Time 타입 내보내기
```
export interface Time {
  startAt: string;
  endAt: string;
  remainingSeats: number;
}

interface Theater {
  theaterId: number;
  theaterName: string;
  maxSeats: number;
  theaterType: string;
  times: Time[];
}
```

2. EachTheatersTimeList에서 Time 타입 가져오기
```
interface EachTheatersTimeListProps {
  times: Time[];
}

function EachTheatersTimeList({ times }: EachTheatersTimeListProps) {
...
        <RunningTimeSeatsWrapper key={time.startAt} startAt={time.startAt} endAt={time.endAt} />
...

```


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 각 상영관의 시간 리스트인 EachTheatersTimeList 컴포넌트에서 시간&좌석을 감싸는 RunningTimeSeatsWrapper 컴포넌트로 데이터를 전달하고,여기에서 예매시간을 나타내는 RunningTime 컴포넌트로 데이터를 전달하는 방법을 사용했습니다! (아래에 박스 그림으로 나타내보았습니다!!)
각 컴포넌트의 역할을 명확하게 하려다보니 컴포넌트가 다소 깊어졌는데, 컴포넌트가 깊어지더라도 이런 식으로 컴포넌트를 나누는게 좋을지...
그래도 컴포넌트의 깊이를 조금 줄이는게 좋을지 ... 고민이 들었습니다!!
팀원분들께서는 이러한 컴포넌트 깊이에 대해서 어떻게 생각하실까요 ?!

<img width="377" alt="스크린샷 2024-05-23 오후 4 16 28" src="https://github.com/NOW-SOPT-CDSP-WEB5/CGV-CLIENT/assets/99737532/d09f7c81-ae55-4cc6-bb86-9e277fabc597">




## 스크린샷 (선택)
![image](https://github.com/NOW-SOPT-CDSP-WEB5/CGV-CLIENT/assets/99737532/c1550917-5968-4452-92cf-e99c9c76870e)

![image](https://github.com/NOW-SOPT-CDSP-WEB5/CGV-CLIENT/assets/99737532/5b520fb6-0720-4f4e-b162-885b674bbbc2)
