### PR TITLE
[FIX] 어긋난 예매취소 모달 UI 수정

### DIFF
--- a/src/components/movie/modal/CancelModal.tsx
+++ b/src/components/movie/modal/CancelModal.tsx
@@ -1,4 +1,3 @@
-import { useState, PropsWithChildren } from 'react';
 import { useState, useEffect, PropsWithChildren } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -38,14 +37,16 @@ function CancelModal({ onClickToggleModal, children }: PropsWithChildren<CancelM
 				<CancelConfirmModal />
 			) : (
 				<>
-					<CancelTitle>
-						예매한 &lt;범죄도시4&gt;
-						<br /> 영화를 취소하시겠어요?
-					</CancelTitle>
-					<Theater>강남 CGV 1관 6층</Theater>
-					<Typo.Title.Title6B18>07:40 ~ 09:39</Typo.Title.Title6B18>
-					<CancelMsg>취소 후 되돌릴 수 없으니 신중하게 선택해주세요</CancelMsg>
-					{children}
+					<BookingModalWrpaper>
+						<CancelTitle>
+							예매한 &lt;범죄도시4&gt;
+							<br /> 영화를 취소하시겠어요?
+						</CancelTitle>
+						<Theater>강남 CGV 1관 6층</Theater>
+						<Typo.Title.Title6B18>07:40 ~ 09:39</Typo.Title.Title6B18>
+						<CancelMsg>취소 후 되돌릴 수 없으니 신중하게 선택해주세요</CancelMsg>
+						{children}
+					</BookingModalWrpaper>
 					<ButtonWrapper>
 						<CloseButton type="button" onClick={onClickToggleModal}>
 							<Typo.Head.Head1SB17>닫기</Typo.Head.Head1SB17>
@@ -59,6 +60,14 @@ function CancelModal({ onClickToggleModal, children }: PropsWithChildren<CancelM
 		</Modal>
 	);
 }
+
+const BookingModalWrpaper = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding-top: 5rem;
+`;
 
 const CancelButton = styled.button`
 	width: 14.7rem;
@@ -89,8 +98,6 @@ const CancelTitle = styled(Typo.Head.Head1SB17)`
 `;
 
 const ButtonWrapper = styled.div`
-	position: fixed;
-	bottom: 30rem;
 	display: flex;
 `;
 
@@ -99,7 +106,7 @@ const Theater = styled(Typo.Title.Title3SB14)`
 `;
 
 const CancelMsg = styled(Typo.Caption.Caption2R11)`
-	padding: 1.2rem 0 3.5rem;
+	padding: 1.2rem 0 2.5rem;
 
 	color: ${({ theme }) => theme.GreyScale.MG};
 `;

--- a/src/components/movie/modal/CancelModal.tsx
+++ b/src/components/movie/modal/CancelModal.tsx
@@ -1,4 +1,6 @@
 import { useState, PropsWithChildren } from 'react';
+import { useState, useEffect, PropsWithChildren } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Modal from '../../common/modal/Modal';
 import Typo from '../../../styles/typo/typo';
@@ -11,10 +13,24 @@ interface CancelModalProps {
 /** 예매취소 모달 내용 */
 function CancelModal({ onClickToggleModal, children }: PropsWithChildren<CancelModalProps>) {
 	const [isCancelConfirmed, setCancelConfirmed] = useState(false);
+	const navigate = useNavigate();
 
 	const handleCancelClick = () => {
 		setCancelConfirmed(true);
 	};
+
+	// 3초 모달 표시되고 닫기
+	useEffect(() => {
+		if (isCancelConfirmed) {
+			const timer = setTimeout(() => {
+				onClickToggleModal();
+				navigate('/movie');
+			}, 3000);
+
+			return () => clearTimeout(timer);
+		}
+		return undefined;
+	}, [isCancelConfirmed, onClickToggleModal, navigate]);
 
 	return (
 		<Modal onClickToggleModal={onClickToggleModal}>

--- a/src/components/time/modal/BookingConfirmModal.tsx
+++ b/src/components/time/modal/BookingConfirmModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import timeImages from '../../../assets/time/images';
 import Typo from '../../../styles/typo/typo';
@@ -9,6 +10,15 @@ interface BookingConfirmModalProps {
 
 /** 예매 확인 모달 */
 function BookingConfirmModal({ onClickToggleModal }: BookingConfirmModalProps) {
+	// 3초 표시되고 닫기
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			onClickToggleModal();
+		}, 3000);
+
+		return () => clearTimeout(timer);
+	}, [onClickToggleModal]);
+
 	return (
 		<Modal onClickToggleModal={onClickToggleModal}>
 			<ConfirmDialogBox>
@@ -48,10 +58,12 @@ const BookingConfirmMsg = styled(Typo.Head.Head1SB17)`
 	bottom: 1rem;
 	margin: 1rem 0;
 `;
+
 const BookingConfirmImg = styled.img`
 	width: 17.8rem;
 	height: 16.3rem;
 `;
+
 const GoAllMovieList = styled(Typo.Body.Body2R12)`
 	position: relative;
 	bottom: 1.4rem;


### PR DESCRIPTION
## 작업 내용 :technologist:

- 어긋난 예매취소 모달 UI 수정
- 확인 모달 3초만 표시되고 닫기도록 구현

## 알게된 점 :rocket:

> 기록하며 개발하기!

-

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex1) 관련 파일은 노션 참고해주세요!
- ex2

## 스크린샷 (선택)
